### PR TITLE
Fix pytest missing error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "slack-bolt>=1.23.0",
   "aiohttp>=3.11.18",
   "openai-agents>=0.0.13",
+  "pytest>=7.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- include pytest in project dependencies so `codex` can run tests

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=62)*
- `pytest -q` *(fails: command not found)*